### PR TITLE
change some  key mapping for traditional user

### DIFF
--- a/src/PYFallbackEditor.cc
+++ b/src/PYFallbackEditor.cc
@@ -152,9 +152,9 @@ FallbackEditor::processPunctForTraditionalChinese (guint keyval, guint keycode, 
             commit ("。");
         return TRUE;
     case '<':
-        commit ("《"); return TRUE;
+        commit ("，"); return TRUE;
     case '>':
-        commit ("》"); return TRUE;
+        commit ("。"); return TRUE;
     case '?':
         commit ("？"); return TRUE;
     }


### PR DESCRIPTION
dear phuang,
this patch just use ， and  。 on shift + < and >  instead of 《 and 》based on traditional user usual behavior.
