### PR TITLE
add options for enter key

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -312,3 +312,15 @@ msgstr "[Shift]键选词"
 #: ../setup/ibus-pinyin-preferences.ui.h:70
 msgid "http://ibus.googlecode.com"
 msgstr "http://ibus.googlecode.com"
+
+msgid "Feature of Enter key:"
+msgstr "Enter 键功能："
+
+msgid "<b>Other</b>"
+msgstr "<b>其他</b>"
+
+msgid "Commit original text"
+msgstr "输出原本的英文字"
+
+msgid "Commit first candidate"
+msgstr "输出第一个候选词"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -307,3 +307,15 @@ msgstr "[Shift]鍵選詞"
 #: ../setup/ibus-pinyin-preferences.ui.h:70
 msgid "http://ibus.googlecode.com"
 msgstr "http://ibus.googlecode.com"
+
+msgid "Feature of Enter key:"
+msgstr "Enter 鍵功能："
+
+msgid "<b>Other</b>"
+msgstr "<b>其他</b>"
+
+msgid "Commit original text"
+msgstr "輸出原本的英文字"
+
+msgid "Commit first candidate"
+msgstr "輸出第一個候選詞"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -307,3 +307,15 @@ msgstr "[Shift]鍵選詞"
 #: ../setup/ibus-pinyin-preferences.ui.h:70
 msgid "http://ibus.googlecode.com"
 msgstr "http://ibus.googlecode.com"
+
+msgid "Feature of Enter key:"
+msgstr "Enter 鍵功能："
+
+msgid "<b>Other</b>"
+msgstr "<b>其他</b>"
+
+msgid "Commit original text"
+msgstr "輸出原本的英文字"
+
+msgid "Commit first candidate"
+msgstr "輸出第一個候選詞"

--- a/setup/ibus-pinyin-preferences.ui
+++ b/setup/ibus-pinyin-preferences.ui
@@ -919,6 +919,81 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkFrame" id="frame10">
+                        <property name="visible">True</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment" id="alignment16">
+                            <property name="visible">True</property>
+                            <property name="top_padding">6</property>
+                            <property name="left_padding">12</property>
+                            <child>
+                              <object class="GtkVBox" id="vbox16">
+                                <property name="visible">True</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel" id="LabelEnter">
+                                    <property name="visible">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Feature of Enter key:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">3</property>
+                                    <property name="bottom_attach">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="CommitFirstCandidate">
+                                    <property name="label" translatable="yes">Commit first candidate</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <property name="group">CommitOriginalText</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">2</property>
+                                    <property name="right_attach">3</property>
+                                    <property name="top_attach">3</property>
+                                    <property name="bottom_attach">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="CommitOriginalText">
+                                    <property name="label" translatable="yes">Commit original text</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">3</property>
+                                    <property name="bottom_attach">4</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel" id="labelOther">
+                            <property name="visible">True</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Other&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/setup/main.py
+++ b/setup/main.py
@@ -196,6 +196,9 @@ class PreferencesDialog:
         self.__auxiliary_select_key_f = self.__builder.get_object("AuxiliarySelectKey_F")
         self.__auxiliary_select_key_kp = self.__builder.get_object("AuxiliarySelectKey_KP")
 
+        # other
+        self.__enter_key = self.__builder.get_object("CommitFirstCandidate")
+
         # read value
         self.__bopomofo_keyboard_mapping.set_active(self.__get_value("BopomofoKeyboardMapping", 0))
         self.__incomplete_bopomofo.set_active(self.__get_value("IncompletePinyin", False))
@@ -203,6 +206,7 @@ class PreferencesDialog:
         self.__guide_key.set_active(self.__get_value("GuideKey", 1))
         self.__auxiliary_select_key_f.set_active(self.__get_value("AuxiliarySelectKey_F", 1))
         self.__auxiliary_select_key_kp.set_active(self.__get_value("AuxiliarySelectKey_KP", 1))
+        self.__enter_key.set_active(self.__get_value("EnterKey", True))
 
         # connect signals
         def __bopomofo_keyboard_mapping_changed_cb(widget):
@@ -216,6 +220,7 @@ class PreferencesDialog:
         self.__guide_key.connect("toggled", self.__toggled_cb, "GuideKey")
         self.__auxiliary_select_key_f.connect("toggled", self.__toggled_cb, "AuxiliarySelectKey_F")
         self.__auxiliary_select_key_kp.connect("toggled", self.__toggled_cb, "AuxiliarySelectKey_KP")
+        self.__enter_key.connect("toggled", self.__toggled_cb, "EnterKey")
 
     def __init_input_custom(self):
         # others

--- a/src/PYBopomofo.h
+++ b/src/PYBopomofo.h
@@ -62,10 +62,11 @@
 #define BOPOMOFO_ANG        (35)
 #define BOPOMOFO_ENG        (36)
 #define BOPOMOFO_ER         (37)
-#define BOPOMOFO_TONE_2     (38)
-#define BOPOMOFO_TONE_3     (39)
-#define BOPOMOFO_TONE_4     (40)
-#define BOPOMOFO_TONE_5     (41)
+#define BOPOMOFO_TONE_1     (38)
+#define BOPOMOFO_TONE_2     (39)
+#define BOPOMOFO_TONE_3     (40)
+#define BOPOMOFO_TONE_4     (41)
+#define BOPOMOFO_TONE_5     (42)
 
 const static wchar_t bopomofo_char[] = {
     L'\0', L'ㄅ', L'ㄆ', L'ㄇ', L'ㄈ', L'ㄉ', L'ㄊ', L'ㄋ', L'ㄌ', L'ㄍ', L'ㄎ',
@@ -74,7 +75,7 @@ const static wchar_t bopomofo_char[] = {
     L'ㄧ', L'ㄨ', L'ㄩ', L'ㄚ', L'ㄛ', L'ㄜ', L'ㄝ', L'ㄞ', L'ㄟ', L'ㄠ', L'ㄡ',
     L'ㄢ', L'ㄣ', L'ㄤ', L'ㄥ', L'ㄦ',
 
-    L'ˊ', L'ˇ', L'ˋ', L'˙',
+    L'ˉ', L'ˊ', L'ˇ', L'ˋ', L'˙',
 };
 
 #endif /* __PY_BOPOMOFO_H_ */

--- a/src/PYBopomofoEditor.cc
+++ b/src/PYBopomofoEditor.cc
@@ -345,7 +345,7 @@ BopomofoEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
         return TRUE;
     if (G_UNLIKELY (processAuxiliarySelectKey (keyval, keycode, modifiers)))
         return TRUE;
-    if (G_UNLIKELY (processBopomofo (keyval, keycode ,modifiers)))
+    if (m_select_mode == FALSE && G_UNLIKELY (processBopomofo (keyval, keycode ,modifiers)))
         return TRUE;
 
     switch (keyval) {
@@ -429,7 +429,7 @@ BopomofoEditor::updateAuxiliaryText (void)
         for (guint sj = 0; m_pinyin[i]->bopomofo[sj] == bopomofo_char[keyvalToBopomofo(m_text.c_str()[si])] ; si++,sj++);
         if (si < m_text_len) {
             gint ch = keyvalToBopomofo(m_text.c_str()[si]);
-            if (ch >= BOPOMOFO_TONE_2 && ch <= BOPOMOFO_TONE_5) {
+            if (ch >= BOPOMOFO_TONE_1 && ch <= BOPOMOFO_TONE_5) {
                 m_buffer.appendUnichar(bopomofo_char[ch]);
                 ++si;
             }

--- a/src/PYBopomofoEditor.cc
+++ b/src/PYBopomofoEditor.cc
@@ -456,7 +456,12 @@ BopomofoEditor::commit (void)
 
     m_buffer.clear ();
 
-    if (m_select_mode) {
+    if (!m_select_mode && m_config.enterKey ()) {
+        m_phrase_editor.selectCandidate(0);
+    }
+
+
+    if (m_select_mode || m_config.enterKey ()) {
         m_buffer << m_phrase_editor.selectedString ();
 
         const gchar *p;

--- a/src/PYBopomofoKeyboard.h
+++ b/src/PYBopomofoKeyboard.h
@@ -25,8 +25,9 @@
 #include "PYBopomofo.h"
 
 static const guint8
-bopomofo_keyboard[][41][2] = {
+bopomofo_keyboard[][42][2] = {
     {
+        { ' ' , BOPOMOFO_TONE_1 },
         { ',' , BOPOMOFO_E2     },
         { '-' , BOPOMOFO_ER     },
         { '.' , BOPOMOFO_OU     },
@@ -70,6 +71,7 @@ bopomofo_keyboard[][41][2] = {
         { 'z' , BOPOMOFO_F      },
     },
     {
+        { ' ' , BOPOMOFO_TONE_1 },
         { '\'', BOPOMOFO_V      },
         { ',' , BOPOMOFO_E2     },
         { '-' , BOPOMOFO_I      },
@@ -113,6 +115,7 @@ bopomofo_keyboard[][41][2] = {
         { 'z' , BOPOMOFO_TONE_4 },
     },
     {
+        { ' ' , BOPOMOFO_TONE_1 },
         { '\'', BOPOMOFO_C      },
         { ',' , BOPOMOFO_ZH     },
         { '-' , BOPOMOFO_ENG    },
@@ -156,6 +159,7 @@ bopomofo_keyboard[][41][2] = {
         { 'z' , BOPOMOFO_AO     },
     },
     {
+        { ' ' , BOPOMOFO_TONE_1 },
         { ',' , BOPOMOFO_TONE_3 },
         { '-' , BOPOMOFO_H      },
         { '.' , BOPOMOFO_TONE_4 },

--- a/src/PYConfig.cc
+++ b/src/PYConfig.cc
@@ -47,6 +47,7 @@ const gchar * const CONFIG_SELECT_KEYS               = "SelectKeys";
 const gchar * const CONFIG_GUIDE_KEY                 = "GuideKey";
 const gchar * const CONFIG_AUXILIARY_SELECT_KEY_F    = "AuxiliarySelectKey_F";
 const gchar * const CONFIG_AUXILIARY_SELECT_KEY_KP   = "AuxiliarySelectKey_KP";
+const gchar * const CONFIG_ENTER_KEY                 = "EnterKey";
 
 std::unique_ptr<PinyinConfig> PinyinConfig::m_instance;
 std::unique_ptr<BopomofoConfig> BopomofoConfig::m_instance;
@@ -460,6 +461,7 @@ BopomofoConfig::readDefaultValues (void)
     m_guide_key = read (CONFIG_GUIDE_KEY, true);
     m_auxiliary_select_key_f = read (CONFIG_AUXILIARY_SELECT_KEY_F, true);
     m_auxiliary_select_key_kp = read (CONFIG_AUXILIARY_SELECT_KEY_KP, true);
+    m_enter_key = read (CONFIG_ENTER_KEY, true);
 }
 
 gboolean
@@ -496,6 +498,8 @@ BopomofoConfig::valueChanged (const std::string & section,
         m_auxiliary_select_key_f = normalizeGValue (value, true);
     else if (CONFIG_AUXILIARY_SELECT_KEY_KP == name)
         m_auxiliary_select_key_kp = normalizeGValue (value, true);
+    else if (CONFIG_ENTER_KEY == name)
+        m_enter_key = normalizeGValue (value, true);
     else
         return FALSE;
     return TRUE;

--- a/src/PYConfig.h
+++ b/src/PYConfig.h
@@ -56,6 +56,7 @@ public:
     gboolean guideKey (void) const              { return m_guide_key; }
     gboolean auxiliarySelectKeyF (void) const   { return m_auxiliary_select_key_f; }
     gboolean auxiliarySelectKeyKP (void) const  { return m_auxiliary_select_key_kp; }
+    gboolean enterKey (void) const  { return m_enter_key; }
 
 protected:
     bool read (const gchar * name, bool defval);
@@ -101,6 +102,8 @@ protected:
     gboolean m_guide_key;
     gboolean m_auxiliary_select_key_f;
     gboolean m_auxiliary_select_key_kp;
+
+    gboolean m_enter_key;
 };
 
 /* PinyinConfig */

--- a/src/PYFallbackEditor.cc
+++ b/src/PYFallbackEditor.cc
@@ -152,9 +152,9 @@ FallbackEditor::processPunctForTraditionalChinese (guint keyval, guint keycode, 
             commit ("。");
         return TRUE;
     case '<':
-        commit ("《"); return TRUE;
+        commit ("，"); return TRUE;
     case '>':
-        commit ("》"); return TRUE;
+        commit ("。"); return TRUE;
     case '?':
         commit ("？"); return TRUE;
     }

--- a/src/PYPinyinParser.cc
+++ b/src/PYPinyinParser.cc
@@ -291,7 +291,8 @@ bopomofo_cmp (const void *p1, const void *p2)
 gboolean
 PinyinParser::isBopomofoToneChar (const wchar_t ch)
 {
-    return ch == bopomofo_char[BOPOMOFO_TONE_2]
+    return ch == bopomofo_char[BOPOMOFO_TONE_1]
+        || ch == bopomofo_char[BOPOMOFO_TONE_2]
         || ch == bopomofo_char[BOPOMOFO_TONE_3]
         || ch == bopomofo_char[BOPOMOFO_TONE_4]
         || ch == bopomofo_char[BOPOMOFO_TONE_5];


### PR DESCRIPTION
Dear Huang,

this patch add new option for enter key, so enter key has two options now,
1) commit original english text
2) commit first candidate

eg. if i type "5j/jpgjbjz8"  and press enter, option 2 will commit 中文輸入法, original feature will commit "5j/jpgjbjz8" for another situation. 

Yuren
